### PR TITLE
#169485408 retrieve and display user's entries in descending order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -339,9 +339,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-      "integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+      "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0"

--- a/server/models/entryModels.js
+++ b/server/models/entryModels.js
@@ -35,7 +35,9 @@ class EntryModel {
   }
 
   getEntries = (req) => {
-    const entries = data.entries.filter((entry) => entry.ownerId === req.payload.id);
+    const sortedEntries = data.entries.sort((a, b) => (new Date(b.createdOn)).getTime()
+      - (new Date(a.createdOn).getTime()));
+    const entries = sortedEntries.filter((entry) => entry.ownerId === req.payload.id);
     if (entries.length < 1) {
 		  return Response.error(NOT_FOUND, 'you do not have any entries now');
 	  }


### PR DESCRIPTION
#### What does this PR do?
- arrange user's entries in descending order
#### Description of Task to be completed
- implement functionality to fetch and display user's entries in descending order
#### How should this be manually tested?
`` Clone this repo ``
`` cd into the main directory ``
`` install the required dependencies ``
`` Set the required environment variables using the sample env file ``
`` git checkout bg-sorted-entries-#169485408 ``
`` Run npm run devstart ``
`` Test the GET method on the /api/v1/entries endpoint on postman ``
#### Any background context you want to provide?
-N/A
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/169485408
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/38111967/67971227-12b6e680-fc15-11e9-9f9c-b9aaae0b5629.png)
